### PR TITLE
Fix wrong date-time value for mysql 5.7.18-0ubuntu0.16.04.1

### DIFF
--- a/sql/initial_load.sql
+++ b/sql/initial_load.sql
@@ -423,6 +423,6 @@ INSERT INTO `sq_map_convention_to_stage` (`convention_id`,`stage_id`) VALUES (1,
 INSERT INTO `sq_map_convention_to_stage` (`convention_id`,`stage_id`) VALUES (1,3);
 
 
-INSERT INTO `sq_stage` (`stage_id`,`stage_name`,`stage_description`,`stage_from`,`stage_to`) VALUES (1,'Main-Stage','Interior big hall in the hotel','0000-00-00 00:00:00','0000-00-00 00:00:00');
-INSERT INTO `sq_stage` (`stage_id`,`stage_name`,`stage_description`,`stage_from`,`stage_to`) VALUES (2,'Club-Stage','','0000-00-00 00:00:00','0000-00-00 00:00:00');
-INSERT INTO `sq_stage` (`stage_id`,`stage_name`,`stage_description`,`stage_from`,`stage_to`) VALUES (3,'Open-Stage','','0000-00-00 00:00:00','0000-00-00 00:00:00');
+INSERT INTO `sq_stage` (`stage_id`,`stage_name`,`stage_description`,`stage_from`,`stage_to`) VALUES (1,'Main-Stage','Interior big hall in the hotel',CURDATE(),CURDATE() + INTERVAL 6 DAY);
+INSERT INTO `sq_stage` (`stage_id`,`stage_name`,`stage_description`,`stage_from`,`stage_to`) VALUES (2,'Club-Stage','',CURDATE(),CURDATE() + INTERVAL 6 DAY);
+INSERT INTO `sq_stage` (`stage_id`,`stage_name`,`stage_description`,`stage_from`,`stage_to`) VALUES (3,'Open-Stage','',CURDATE(),CURDATE() + INTERVAL 6 DAY);


### PR DESCRIPTION
As the server might run at the current `ubuntu LTS`, I tried to run the installation scripts on a bare VM for this distro and got the following error output for `sql/initial_load.sql`:
```mysql
ERROR 1292 (22007) at line 426: Incorrect datetime value: '0000-00-00 00:00:00' for column 'stage_from' at row 1
```
using `mysqld  Ver 5.7.18-0ubuntu0.16.04.1 for Linux on x86_64 ((Ubuntu))`

**My commit should fix this.**